### PR TITLE
Fix loggers in tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ source =
 omit =
     tests/*
     version.py
+    src/train/*
 
 [coverage:report]
 show_missing = True

--- a/src/detector/detector.py
+++ b/src/detector/detector.py
@@ -1,25 +1,18 @@
-import ast
-from datetime import datetime
-from enum import Enum, unique
 import hashlib
 import json
 import logging
 import os
 import sys
-import importlib
-import joblib
-import numpy as np
 import tempfile
+
+import joblib
 import requests
-import xgboost
-from streamad.util import StreamGenerator, CustomDS
 
 sys.path.append(os.getcwd())
 from src.base.utils import setup_config
 from src.base.kafka_handler import (
     KafkaConsumeHandler,
     KafkaMessageFetchException,
-    KafkaProduceHandler,
 )
 from src.base.log_config import setup_logging
 
@@ -115,10 +108,12 @@ class Detector:
         return h.hexdigest()
 
     def _get_model(self) -> None:
-        """Downloads model from server. If model already exists, it returns the current model. In addition, it checks the sha256 sum in case a model has been updated."""
+        """
+        Downloads model from server. If model already exists, it returns the current model. In addition, it checks the
+        sha256 sum in case a model has been updated.
+        """
 
         if not os.path.isfile(self.model_path):
-
             response = requests.get(
                 f"{MODEL_BASE_URL}/files/?p=%2F{MODEL}_{CHECKSUM}.pkl&dl=1"
             )

--- a/tests/test_batch_handler.py
+++ b/tests/test_batch_handler.py
@@ -33,13 +33,14 @@ class TestDel(unittest.TestCase):
 
 
 class TestAddMessage(unittest.TestCase):
+    @patch('src.logcollector.batch_handler.logger')
     @patch("src.logcollector.batch_handler.BATCH_SIZE", 1000)
     @patch("src.logcollector.batch_handler.KafkaProduceHandler")
     @patch("src.logcollector.batch_handler.CollectorKafkaBatchSender._reset_timer")
     @patch("src.logcollector.batch_handler.BufferedBatch.get_number_of_messages")
     @patch("src.logcollector.batch_handler.CollectorKafkaBatchSender._send_batch_for_key")
     def test_add_message_normal(self, mock_send_batch, mock_get_nr_messages, mock_reset_timer,
-                                mock_produce_handler):
+                                mock_produce_handler, mock_logger):
         # Arrange
         mock_produce_handler_instance = MagicMock()
         mock_produce_handler.return_value = mock_produce_handler_instance
@@ -59,10 +60,11 @@ class TestAddMessage(unittest.TestCase):
         mock_get_nr_messages.assert_called_once_with(key)
         mock_reset_timer.assert_not_called()
 
+    @patch('src.logcollector.batch_handler.logger')
     @patch("src.logcollector.batch_handler.BATCH_SIZE", 100)
     @patch("src.logcollector.batch_handler.KafkaProduceHandler")
     @patch("src.logcollector.batch_handler.CollectorKafkaBatchSender._send_batch_for_key")
-    def test_add_message_full_messages(self, mock_send_batch, mock_produce_handler):
+    def test_add_message_full_messages(self, mock_send_batch, mock_produce_handler, mock_logger):
         # Arrange
         mock_produce_handler_instance = MagicMock()
         mock_produce_handler.return_value = mock_produce_handler_instance
@@ -81,10 +83,11 @@ class TestAddMessage(unittest.TestCase):
         sut.add_message(key, f"message_100")
         mock_send_batch.assert_called_once()
 
+    @patch('src.logcollector.batch_handler.logger')
     @patch("src.logcollector.batch_handler.BATCH_SIZE", 100)
     @patch("src.logcollector.batch_handler.KafkaProduceHandler")
     @patch("src.logcollector.batch_handler.CollectorKafkaBatchSender._send_batch_for_key")
-    def test_add_message_full_messages_with_different_keys(self, mock_send_batch, mock_produce_handler):
+    def test_add_message_full_messages_with_different_keys(self, mock_send_batch, mock_produce_handler, mock_logger):
         # Arrange
         mock_produce_handler_instance = MagicMock()
         mock_produce_handler.return_value = mock_produce_handler_instance
@@ -108,10 +111,11 @@ class TestAddMessage(unittest.TestCase):
         sut.add_message(key, f"message_100")
         mock_send_batch.assert_called_once()
 
+    @patch('src.logcollector.batch_handler.logger')
     @patch("src.logcollector.batch_handler.BATCH_SIZE", 100)
     @patch("src.logcollector.batch_handler.KafkaProduceHandler")
     @patch("src.logcollector.batch_handler.CollectorKafkaBatchSender._reset_timer")
-    def test_add_message_no_timer(self, mock_reset_timer, mock_produce_handler):
+    def test_add_message_no_timer(self, mock_reset_timer, mock_produce_handler, mock_logger):
         # Arrange
         mock_produce_handler_instance = MagicMock()
         mock_produce_handler.return_value = mock_produce_handler_instance
@@ -127,11 +131,12 @@ class TestAddMessage(unittest.TestCase):
 
 
 class TestSendAllBatches(unittest.TestCase):
+    @patch('src.logcollector.batch_handler.logger')
     @patch("src.logcollector.batch_handler.KafkaProduceHandler")
     @patch("src.logcollector.batch_handler.CollectorKafkaBatchSender._send_batch_for_key")
     @patch("src.logcollector.batch_handler.BufferedBatch")
     def test_send_all_batches_with_existing_keys(self, mock_buffered_batch, mock_send_batch,
-                                                 mock_kafka_produce_handler):
+                                                 mock_kafka_produce_handler, mock_logger):
         # Arrange
         mock_batch_instance = MagicMock()
         mock_buffered_batch.return_value = mock_batch_instance
@@ -169,12 +174,14 @@ class TestSendAllBatches(unittest.TestCase):
         # Assert
         self.assertEqual(mock_send_batch.call_count, 0)
 
+    @patch('src.logcollector.batch_handler.logger')
     @patch("src.logcollector.batch_handler.KafkaProduceHandler")
     @patch("src.logcollector.batch_handler.CollectorKafkaBatchSender._send_batch_for_key")
     @patch("src.logcollector.batch_handler.CollectorKafkaBatchSender._reset_timer")
     @patch("src.logcollector.batch_handler.BufferedBatch")
     def test_send_all_batches_with_existing_keys_and_reset_timer(self, mock_buffered_batch, mock_reset_timer,
-                                                                 mock_send_batch, mock_kafka_produce_handler):
+                                                                 mock_send_batch, mock_kafka_produce_handler,
+                                                                 mock_logger):
         # Arrange
         mock_batch_instance = MagicMock()
         mock_buffered_batch.return_value = mock_batch_instance

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,5 +1,5 @@
-from datetime import datetime, timedelta
 import unittest
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from src.base import Batch
@@ -23,10 +23,11 @@ class TestInit(unittest.TestCase):
 
 
 class TestGetData(unittest.TestCase):
+    @patch('src.inspector.inspector.logger')
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     def test_get_data_without_return_data(
-        self, mock_kafka_consume_handler, mock_produce_handler
+            self, mock_kafka_consume_handler, mock_produce_handler, mock_logger
     ):
         test_batch = Batch(
             begin_timestamp=datetime.now(),
@@ -47,10 +48,11 @@ class TestGetData(unittest.TestCase):
 
         self.assertEqual([], sut.messages)
 
+    @patch('src.inspector.inspector.logger')
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     def test_get_data_with_return_data(
-        self, mock_kafka_consume_handler, mock_produce_handler
+            self, mock_kafka_consume_handler, mock_produce_handler, mock_logger
     ):
         begin = datetime.now()
         end = begin + timedelta(0, 3)
@@ -81,7 +83,7 @@ class TestGetData(unittest.TestCase):
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     def test_get_data_while_busy(
-        self, mock_kafka_consume_handler, mock_produce_handler
+            self, mock_kafka_consume_handler, mock_produce_handler
     ):
         mock_kafka_consume_handler_instance = MagicMock()
         mock_kafka_consume_handler.return_value = mock_kafka_consume_handler_instance
@@ -107,7 +109,7 @@ class TestClearData(unittest.TestCase):
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     def test_clear_data_without_existing_data(
-        self, mock_kafka_consume_handler, mock_produce_handler
+            self, mock_kafka_consume_handler, mock_produce_handler
     ):
         mock_kafka_consume_handler_instance = MagicMock()
         mock_kafka_consume_handler.return_value = mock_kafka_consume_handler_instance
@@ -128,7 +130,7 @@ class TestClearData(unittest.TestCase):
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     def test_clear_data_with_existing_data(
-        self, mock_kafka_consume_handler, mock_produce_handler
+            self, mock_kafka_consume_handler, mock_produce_handler
     ):
         mock_kafka_consume_handler_instance = MagicMock()
         mock_kafka_consume_handler.return_value = mock_kafka_consume_handler_instance
@@ -214,7 +216,7 @@ class TestDataFunction(unittest.TestCase):
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     def test_count_errors_empty_messages(
-        self, mock_kafka_consume_handler, mock_produce_handler
+            self, mock_kafka_consume_handler, mock_produce_handler
     ):
         mock_kafka_consume_handler_instance = MagicMock()
         mock_kafka_consume_handler.return_value = mock_kafka_consume_handler_instance
@@ -232,7 +234,7 @@ class TestDataFunction(unittest.TestCase):
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     def test_mean_packet_size_empty_messages(
-        self, mock_kafka_consume_handler, mock_produce_handler
+            self, mock_kafka_consume_handler, mock_produce_handler
     ):
         mock_kafka_consume_handler_instance = MagicMock()
         mock_kafka_consume_handler.return_value = mock_kafka_consume_handler_instance
@@ -249,13 +251,14 @@ class TestDataFunction(unittest.TestCase):
 
 
 class TestInspectFunction(unittest.TestCase):
+    @patch('src.inspector.inspector.logger')
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     @patch(
         "src.inspector.inspector.MODELS",
         [{"model": "ZScoreDetector", "module": "streamad.model", "model_args": {}}],
     )
-    def test_inspect_univariate(self, mock_kafka_consume_handler, mock_produce_handler):
+    def test_inspect_univariate(self, mock_kafka_consume_handler, mock_produce_handler, mock_logger):
         test_batch = Batch(
             begin_timestamp=datetime.now(),
             end_timestamp=datetime.now() + timedelta(0, 3),
@@ -275,6 +278,7 @@ class TestInspectFunction(unittest.TestCase):
         sut.inspect()
         self.assertIsNotNone(sut.anomalies)
 
+    @patch('src.inspector.inspector.logger')
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     @patch(
@@ -283,7 +287,7 @@ class TestInspectFunction(unittest.TestCase):
     )
     @patch("src.inspector.inspector.MODE", "multivariate")
     def test_inspect_multivariate(
-        self, mock_kafka_consume_handler, mock_produce_handler
+            self, mock_kafka_consume_handler, mock_produce_handler, mock_logger
     ):
         test_batch = Batch(
             begin_timestamp=datetime.now(),
@@ -304,6 +308,7 @@ class TestInspectFunction(unittest.TestCase):
         sut.inspect()
         self.assertIsNotNone(sut.anomalies)
 
+    @patch('src.inspector.inspector.logger')
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     @patch(
@@ -311,7 +316,7 @@ class TestInspectFunction(unittest.TestCase):
         [{"model": "INVALID", "module": "streamad.model"}],
     )
     def test_invalid_model_univariate(
-        self, mock_kafka_consume_handler, mock_produce_handler
+            self, mock_kafka_consume_handler, mock_produce_handler, mock_logger
     ):
         mock_kafka_consume_handler_instance = MagicMock()
         mock_kafka_consume_handler.return_value = mock_kafka_consume_handler_instance
@@ -322,6 +327,7 @@ class TestInspectFunction(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             sut.inspect()
 
+    @patch('src.inspector.inspector.logger')
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     @patch(
@@ -330,7 +336,7 @@ class TestInspectFunction(unittest.TestCase):
     )
     @patch("src.inspector.inspector.MODE", "multivariate")
     def test_invalid_model_multivariate(
-        self, mock_kafka_consume_handler, mock_produce_handler
+            self, mock_kafka_consume_handler, mock_produce_handler, mock_logger
     ):
         mock_kafka_consume_handler_instance = MagicMock()
         mock_kafka_consume_handler.return_value = mock_kafka_consume_handler_instance
@@ -341,6 +347,7 @@ class TestInspectFunction(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             sut.inspect()
 
+    @patch('src.inspector.inspector.logger')
     @patch("src.inspector.inspector.KafkaProduceHandler")
     @patch("src.inspector.inspector.KafkaConsumeHandler")
     @patch(
@@ -349,7 +356,7 @@ class TestInspectFunction(unittest.TestCase):
     )
     @patch("src.inspector.inspector.MODE", "ensemble")
     def test_invalid_model_ensemble(
-        self, mock_kafka_consume_handler, mock_produce_handler
+            self, mock_kafka_consume_handler, mock_produce_handler, mock_logger
     ):
         mock_kafka_consume_handler_instance = MagicMock()
         mock_kafka_consume_handler.return_value = mock_kafka_consume_handler_instance
@@ -375,8 +382,9 @@ class TestInspectFunction(unittest.TestCase):
 
 
 class TestMainFunction(unittest.TestCase):
+    @patch('src.inspector.inspector.logger')
     @patch("src.inspector.inspector.Inspector")
-    def test_main_loop_execution(self, mock_inspector):
+    def test_main_loop_execution(self, mock_inspector, mock_logger):
         # Arrange
         mock_inspector_instance = mock_inspector.return_value
 
@@ -390,16 +398,17 @@ class TestMainFunction(unittest.TestCase):
         self.assertTrue(mock_inspector_instance.get_and_fill_data.called)
         self.assertTrue(mock_inspector_instance.clear_data.called)
 
+    @patch('src.inspector.inspector.logger')
     @patch("src.inspector.inspector.Inspector")
-    def test_main_io_error_handling(self, mock_inspector):
+    def test_main_io_error_handling(self, mock_inspector, mock_logger):
         # Arrange
         mock_inspector_instance = mock_inspector.return_value
 
         # Act
         with patch.object(
-            mock_inspector_instance,
-            "get_and_fill_data",
-            side_effect=IOError("Simulated IOError"),
+                mock_inspector_instance,
+                "get_and_fill_data",
+                side_effect=IOError("Simulated IOError"),
         ):
             with self.assertRaises(IOError):
                 main(one_iteration=True)
@@ -408,16 +417,17 @@ class TestMainFunction(unittest.TestCase):
         self.assertTrue(mock_inspector_instance.clear_data.called)
         self.assertTrue(mock_inspector_instance.loop_exited)
 
+    @patch('src.inspector.inspector.logger')
     @patch("src.inspector.inspector.Inspector")
-    def test_main_value_error_handling(self, mock_inspector):
+    def test_main_value_error_handling(self, mock_inspector, mock_logger):
         # Arrange
         mock_inspector_instance = mock_inspector.return_value
 
         # Act
         with patch.object(
-            mock_inspector_instance,
-            "get_and_fill_data",
-            side_effect=ValueError("Simulated ValueError"),
+                mock_inspector_instance,
+                "get_and_fill_data",
+                side_effect=ValueError("Simulated ValueError"),
         ):
             main(one_iteration=True)
 
@@ -425,8 +435,9 @@ class TestMainFunction(unittest.TestCase):
         self.assertTrue(mock_inspector_instance.clear_data.called)
         self.assertTrue(mock_inspector_instance.loop_exited)
 
+    @patch('src.inspector.inspector.logger')
     @patch("src.inspector.inspector.Inspector")
-    def test_main_keyboard_interrupt(self, mock_inspector):
+    def test_main_keyboard_interrupt(self, mock_inspector, mock_logger):
         # Arrange
         mock_inspector_instance = mock_inspector.return_value
         mock_inspector_instance.get_and_fill_data.side_effect = KeyboardInterrupt

--- a/tests/test_kafka_consume_handler.py
+++ b/tests/test_kafka_consume_handler.py
@@ -35,6 +35,7 @@ class TestInit(unittest.TestCase):
         mock_consumer.assert_called_once_with(expected_conf)
         mock_consumer_instance.assign.assert_called_once()
 
+    @patch('src.base.kafka_handler.logger')
     @patch("src.base.kafka_handler.CONSUMER_GROUP_ID", "test_group_id")
     @patch("src.base.kafka_handler.KAFKA_BROKERS", [
         {'hostname': '127.0.0.1', 'port': 9999, },
@@ -42,7 +43,7 @@ class TestInit(unittest.TestCase):
         {'hostname': '127.0.0.3', 'port': 9997, },
     ])
     @patch("src.base.kafka_handler.Consumer")
-    def test_init_fail(self, mock_consumer):
+    def test_init_fail(self, mock_consumer, mock_logger):
         mock_consumer_instance = MagicMock()
         mock_consumer.return_value = mock_consumer_instance
 

--- a/tests/test_kafka_produce_handler.py
+++ b/tests/test_kafka_produce_handler.py
@@ -30,13 +30,14 @@ class TestInit(unittest.TestCase):
         mock_producer.assert_called_once_with(expected_conf)
         mock_producer_instance.init_transactions.assert_called_once()
 
+    @patch('src.base.kafka_handler.logger')
     @patch("src.base.kafka_handler.KAFKA_BROKERS", [
         {'hostname': '127.0.0.1', 'port': 9999, },
         {'hostname': '127.0.0.2', 'port': 9998, },
         {'hostname': '127.0.0.3', 'port': 9997, },
     ])
     @patch("src.base.kafka_handler.Producer")
-    def test_init_fail(self, mock_producer):
+    def test_init_fail(self, mock_producer, mock_logger):
         mock_producer_instance = MagicMock()
         mock_producer.return_value = mock_producer_instance
 
@@ -98,6 +99,7 @@ class TestSend(unittest.TestCase):
         mock_producer.produce.assert_not_called()
         mock_producer.commit_transaction_with_retry.assert_not_called()
 
+    @patch('src.base.kafka_handler.logger')
     @patch("src.base.kafka_handler.KAFKA_BROKERS", [
         {'hostname': '127.0.0.1', 'port': 9999, },
         {'hostname': '127.0.0.2', 'port': 9998, },
@@ -111,6 +113,7 @@ class TestSend(unittest.TestCase):
             mock_commit_transaction_with_retry,
             mock_kafka_delivery_report,
             mock_producer,
+            mock_logger,
     ):
         mock_producer_instance = MagicMock()
         mock_producer.return_value = mock_producer_instance
@@ -175,6 +178,7 @@ class TestCommitTransactionWithRetry(unittest.TestCase):
         self.assertEqual(mock_producer_instance.commit_transaction.call_count, 2)
         mock_sleep.assert_called_once_with(1.0)
 
+    @patch('src.base.kafka_handler.logger')
     @patch("src.base.kafka_handler.KAFKA_BROKERS", [
         {'hostname': '127.0.0.1', 'port': 9999, },
         {'hostname': '127.0.0.2', 'port': 9998, },
@@ -182,7 +186,7 @@ class TestCommitTransactionWithRetry(unittest.TestCase):
     ])
     @patch("src.base.kafka_handler.Producer")
     @patch("time.sleep", return_value=None)
-    def test_commit_retries_and_fails(self, mock_sleep, mock_producer):
+    def test_commit_retries_and_fails(self, mock_sleep, mock_producer, mock_logger):
         mock_producer_instance = MagicMock()
         mock_producer.return_value = mock_producer_instance
         mock_producer_instance.commit_transaction.side_effect = KafkaException(

--- a/tests/test_logline_handler.py
+++ b/tests/test_logline_handler.py
@@ -167,6 +167,7 @@ class TestValidateLogline(unittest.TestCase):
             "2024-07-28T14:45:30.123Z NXDOMAIN 127.0.0.2 126.24.5.20 domain.test A fe80::1 150b"
         ))
 
+    @patch('src.base.logline_handler.logger')
     @patch('src.base.logline_handler.REQUIRED_FIELDS', MOCK_REQUIRED_FIELDS)
     @patch('src.base.logline_handler.CONFIG', {
         "loglines": {
@@ -177,7 +178,7 @@ class TestValidateLogline(unittest.TestCase):
             ]
         }
     })
-    def test_validate_wrong_number_of_fields(self):
+    def test_validate_wrong_number_of_fields(self, mock_logger):
         # Arrange
         sut = LoglineHandler()
 
@@ -186,6 +187,7 @@ class TestValidateLogline(unittest.TestCase):
             "2024-07-28T14:45:30.123Z NXDOMAIN 126.24.5.20 test"
         ))
 
+    @patch('src.base.logline_handler.logger')
     @patch('src.base.logline_handler.REQUIRED_FIELDS', MOCK_REQUIRED_FIELDS)
     @patch('src.base.logline_handler.CONFIG', {
         "loglines": {
@@ -196,13 +198,14 @@ class TestValidateLogline(unittest.TestCase):
             ]
         }
     })
-    def test_validate_empty(self):
+    def test_validate_empty(self, mock_logger):
         # Arrange
         sut = LoglineHandler()
 
         # Act and Assert
         self.assertFalse(sut.validate_logline(""))
 
+    @patch('src.base.logline_handler.logger')
     @patch('src.base.logline_handler.REQUIRED_FIELDS', MOCK_REQUIRED_FIELDS)
     @patch('src.base.logline_handler.CONFIG', {
         "loglines": {
@@ -213,7 +216,7 @@ class TestValidateLogline(unittest.TestCase):
             ]
         }
     })
-    def test_validate_contains_invalid_fields(self):
+    def test_validate_contains_invalid_fields(self, mock_logger):
         # Arrange
         sut = LoglineHandler()
 
@@ -222,6 +225,7 @@ class TestValidateLogline(unittest.TestCase):
             "2024-07-28T14:45:30.123Z NXDOMAIN 126.24.5.300"
         ))
 
+    @patch('src.base.logline_handler.logger')
     @patch('src.base.logline_handler.REQUIRED_FIELDS', MOCK_REQUIRED_FIELDS)
     @patch('src.base.logline_handler.CONFIG', {
         "loglines": {
@@ -232,7 +236,7 @@ class TestValidateLogline(unittest.TestCase):
             ]
         }
     })
-    def test_validate_wrong_order_of_fields(self):
+    def test_validate_wrong_order_of_fields(self, mock_logger):
         # Arrange
         sut = LoglineHandler()
 
@@ -278,6 +282,7 @@ class TestValidateLoglineAndGetFieldsAsJson(unittest.TestCase):
             "2024-07-28T14:45:30.123Z NXDOMAIN 127.0.0.2 126.24.5.20 domain.test A fe80::1 150b"
         ))
 
+    @patch('src.base.logline_handler.logger')
     @patch('src.base.logline_handler.REQUIRED_FIELDS', MOCK_REQUIRED_FIELDS)
     @patch('src.base.logline_handler.CONFIG', {
         "loglines": {
@@ -288,7 +293,7 @@ class TestValidateLoglineAndGetFieldsAsJson(unittest.TestCase):
             ]
         }
     })
-    def test_validate_false(self):
+    def test_validate_false(self, mock_logger):
         # Arrange
         sut = LoglineHandler()
 

--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -1,10 +1,8 @@
 import unittest
-from unittest.mock import MagicMock, patch
 
 import marshmallow_dataclass
 
 from src.base import Batch
-from src.detector.detector import Detector, main
 
 
 class TestClearData(unittest.TestCase):
@@ -30,3 +28,7 @@ class TestClearData(unittest.TestCase):
         data_batch = base_schema.load(json_data)
         json_data_deserialized = base_schema.dump(data_batch)
         self.assertEqual(json_data_deserialized, json_data)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_prefilter.py
+++ b/tests/test_prefilter.py
@@ -29,10 +29,12 @@ class TestInit(unittest.TestCase):
 
 
 class TestGetAndFillData(unittest.TestCase):
+    @patch('src.prefilter.prefilter.logger')
     @patch("src.prefilter.prefilter.LoglineHandler")
     @patch("src.prefilter.prefilter.KafkaConsumeHandler")
     @patch("src.prefilter.prefilter.KafkaProduceHandler")
-    def test_get_data_without_new_data(self, mock_produce_handler, mock_consume_handler, mock_logline_handler):
+    def test_get_data_without_new_data(self, mock_produce_handler, mock_consume_handler, mock_logline_handler,
+                                       mock_logger):
         mock_produce_handler_instance = MagicMock()
         mock_produce_handler.return_value = mock_produce_handler_instance
         mock_consume_handler_instance = MagicMock()
@@ -48,10 +50,12 @@ class TestGetAndFillData(unittest.TestCase):
 
         mock_consume_handler_instance.consume_and_return_json_data.assert_called_once()
 
+    @patch('src.prefilter.prefilter.logger')
     @patch("src.prefilter.prefilter.LoglineHandler")
     @patch("src.prefilter.prefilter.KafkaConsumeHandler")
     @patch("src.prefilter.prefilter.KafkaProduceHandler")
-    def test_get_data_with_new_data(self, mock_produce_handler, mock_consume_handler, mock_logline_handler):
+    def test_get_data_with_new_data(self, mock_produce_handler, mock_consume_handler, mock_logline_handler,
+                                    mock_logger):
         mock_produce_handler_instance = MagicMock()
         mock_produce_handler.return_value = mock_produce_handler_instance
         mock_consume_handler_instance = MagicMock()
@@ -71,10 +75,12 @@ class TestGetAndFillData(unittest.TestCase):
 
         mock_consume_handler_instance.consume_and_return_json_data.assert_called_once()
 
+    @patch('src.prefilter.prefilter.logger')
     @patch("src.prefilter.prefilter.LoglineHandler")
     @patch("src.prefilter.prefilter.KafkaConsumeHandler")
     @patch("src.prefilter.prefilter.KafkaProduceHandler")
-    def test_get_data_with_existing_data(self, mock_batch_handler, mock_consume_handler, mock_logline_handler):
+    def test_get_data_with_existing_data(self, mock_batch_handler, mock_consume_handler, mock_logline_handler,
+                                         mock_logger):
         mock_batch_handler_instance = MagicMock()
         mock_batch_handler.return_value = mock_batch_handler_instance
         mock_consume_handler_instance = MagicMock()
@@ -97,10 +103,12 @@ class TestGetAndFillData(unittest.TestCase):
 
 
 class TestFilterByError(unittest.TestCase):
+    @patch('src.prefilter.prefilter.logger')
     @patch("src.prefilter.prefilter.LoglineHandler")
     @patch("src.prefilter.prefilter.KafkaConsumeHandler")
     @patch("src.prefilter.prefilter.KafkaProduceHandler")
-    def test_filter_by_error_empty_data(self, mock_produce_handler, mock_consume_handler, mock_logline_handler):
+    def test_filter_by_error_empty_data(self, mock_produce_handler, mock_consume_handler, mock_logline_handler,
+                                        mock_logger):
         sut = Prefilter()
         sut.unfiltered_data = []
 
@@ -108,11 +116,12 @@ class TestFilterByError(unittest.TestCase):
 
         self.assertEqual([], sut.filtered_data)
 
+    @patch('src.prefilter.prefilter.logger')
     @patch("src.prefilter.prefilter.LoglineHandler")
     @patch("src.prefilter.prefilter.KafkaConsumeHandler")
     @patch("src.prefilter.prefilter.KafkaProduceHandler")
     def test_filter_by_error_with_data_no_error_types(self, mock_produce_handler, mock_consume_handler,
-                                                      mock_logline_handler):
+                                                      mock_logline_handler, mock_logger):
         first_entry = json.dumps({
             "timestamp": "2024-05-21T08:31:28.119Z",
             "status_code": "NOERROR",
@@ -152,11 +161,12 @@ class TestFilterByError(unittest.TestCase):
 
         self.assertEqual([], sut.filtered_data)
 
+    @patch('src.prefilter.prefilter.logger')
     @patch("src.prefilter.prefilter.LoglineHandler")
     @patch("src.prefilter.prefilter.KafkaConsumeHandler")
     @patch("src.prefilter.prefilter.KafkaProduceHandler")
     def test_filter_by_error_with_data_one_error_type(self, mock_produce_handler, mock_consume_handler,
-                                                      mock_logline_handler):
+                                                      mock_logline_handler, mock_logger):
         first_entry = json.dumps({
             "timestamp": "2024-05-21T08:31:28.119Z",
             "status_code": "NOERROR",
@@ -196,11 +206,12 @@ class TestFilterByError(unittest.TestCase):
 
         self.assertEqual([second_entry, third_entry], sut.filtered_data)
 
+    @patch('src.prefilter.prefilter.logger')
     @patch("src.prefilter.prefilter.LoglineHandler")
     @patch("src.prefilter.prefilter.KafkaConsumeHandler")
     @patch("src.prefilter.prefilter.KafkaProduceHandler")
     def test_filter_by_error_with_data_two_error_types(self, mock_produce_handler, mock_consume_handler,
-                                                       mock_logline_handler):
+                                                       mock_logline_handler, mock_logger):
         first_entry = json.dumps({
             "timestamp": "2024-05-21T08:31:28.119Z",
             "status_code": "NOERROR",
@@ -242,10 +253,11 @@ class TestFilterByError(unittest.TestCase):
 
 
 class TestSendFilteredData(unittest.TestCase):
+    @patch('src.prefilter.prefilter.logger')
     @patch("src.prefilter.prefilter.LoglineHandler")
     @patch("src.prefilter.prefilter.KafkaConsumeHandler")
     @patch("src.prefilter.prefilter.KafkaProduceHandler")
-    def test_send_with_data(self, mock_produce_handler, mock_consume_handler, mock_logline_handler):
+    def test_send_with_data(self, mock_produce_handler, mock_consume_handler, mock_logline_handler, mock_logger):
         mock_produce_handler_instance = MagicMock()
         mock_produce_handler.return_value = mock_produce_handler_instance
 
@@ -291,11 +303,12 @@ class TestSendFilteredData(unittest.TestCase):
             topic="Inspect", data=expected_message, key="192.168.1.0_24",
         )
 
+    @patch('src.prefilter.prefilter.logger')
     @patch("src.prefilter.prefilter.LoglineHandler")
     @patch("src.prefilter.prefilter.KafkaConsumeHandler")
     @patch("src.prefilter.prefilter.KafkaProduceHandler")
     def test_send_without_filtered_data_with_unfiltered_data(self, mock_produce_handler, mock_consume_handler,
-                                                             mock_logline_handler):
+                                                             mock_logline_handler, mock_logger):
         mock_produce_handler_instance = MagicMock()
         mock_produce_handler.return_value = mock_produce_handler_instance
 
@@ -372,8 +385,9 @@ class TestClearData(unittest.TestCase):
 
 
 class TestMainFunction(unittest.IsolatedAsyncioTestCase):
+    @patch('src.prefilter.prefilter.logger')
     @patch('src.prefilter.prefilter.Prefilter')
-    async def test_main_normal_flow(self, mock_prefilter):
+    async def test_main_normal_flow(self, mock_prefilter, mock_logger):
         # Arrange
         mock_prefilter_instance = mock_prefilter.return_value
         mock_prefilter_instance.get_and_fill_data.return_value = MagicMock()
@@ -390,8 +404,9 @@ class TestMainFunction(unittest.IsolatedAsyncioTestCase):
         mock_prefilter_instance.send_filtered_data.assert_called()
         mock_prefilter_instance.clear_data.assert_called()
 
+    @patch('src.prefilter.prefilter.logger')
     @patch('src.prefilter.prefilter.Prefilter')
-    async def test_main_ioerror(self, mock_prefilter):
+    async def test_main_ioerror(self, mock_prefilter, mock_logger):
         # Arrange
         mock_prefilter_instance = mock_prefilter.return_value
         mock_prefilter_instance.clear_data.return_value = MagicMock()
@@ -403,8 +418,9 @@ class TestMainFunction(unittest.IsolatedAsyncioTestCase):
 
         mock_prefilter_instance.clear_data.assert_called()
 
+    @patch('src.prefilter.prefilter.logger')
     @patch('src.prefilter.prefilter.Prefilter')
-    async def test_main_valueerror(self, mock_prefilter):
+    async def test_main_valueerror(self, mock_prefilter, mock_logger):
         # Arrange
         mock_prefilter_instance = mock_prefilter.return_value
         mock_prefilter_instance.clear_data.return_value = MagicMock()
@@ -416,8 +432,9 @@ class TestMainFunction(unittest.IsolatedAsyncioTestCase):
         # Assert
         mock_prefilter_instance.clear_data.assert_called()
 
+    @patch('src.prefilter.prefilter.logger')
     @patch('src.prefilter.prefilter.Prefilter')
-    async def test_main_kafka_message_fetch_exception(self, mock_prefilter):
+    async def test_main_kafka_message_fetch_exception(self, mock_prefilter, mock_logger):
         # Arrange
         mock_prefilter_instance = mock_prefilter.return_value
         mock_prefilter_instance.clear_data.return_value = MagicMock()
@@ -429,8 +446,9 @@ class TestMainFunction(unittest.IsolatedAsyncioTestCase):
         # Assert
         mock_prefilter_instance.clear_data.assert_called()
 
+    @patch('src.prefilter.prefilter.logger')
     @patch('src.prefilter.prefilter.Prefilter')
-    async def test_main_keyboard_interrupt(self, mock_prefilter):
+    async def test_main_keyboard_interrupt(self, mock_prefilter, mock_logger):
         # Arrange
         mock_prefilter_instance = mock_prefilter.return_value
         mock_prefilter_instance.clear_data.return_value = MagicMock()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -42,10 +42,11 @@ class TestInit(unittest.TestCase):
 
 
 class TestOpen(unittest.IsolatedAsyncioTestCase):
+    @patch('src.logserver.server.logger')
     @patch("src.logserver.server.HOSTNAME", "127.0.0.1")
     @patch("src.logserver.server.PORT_IN", 1234)
     @patch("src.logserver.server.PORT_OUT", 5678)
-    async def test_open(self):
+    async def test_open(self, mock_logger):
         # Arrange
         sut = LogServer()
 
@@ -77,10 +78,11 @@ class TestOpen(unittest.IsolatedAsyncioTestCase):
             mock_send_server.wait_closed.assert_awaited_once()
             mock_receive_server.wait_closed.assert_awaited_once()
 
+    @patch('src.logserver.server.logger')
     @patch("src.logserver.server.HOSTNAME", "127.0.0.1")
     @patch("src.logserver.server.PORT_IN", 1234)
     @patch("src.logserver.server.PORT_OUT", 5678)
-    async def test_open_keyboard_interrupt(self):
+    async def test_open_keyboard_interrupt(self, mock_logger):
         # Arrange
         sut = LogServer()
 
@@ -183,8 +185,9 @@ class TestHandleConnection(unittest.IsolatedAsyncioTestCase):
         writer.wait_closed.assert_awaited_once()
         self.assertEqual(0, server_instance.number_of_connections)
 
+    @patch('src.logserver.server.logger')
     @patch("src.logserver.server.MAX_NUMBER_OF_CONNECTIONS", 7)
-    async def test_handle_connection_rejects_additional_connections(self):
+    async def test_handle_connection_rejects_additional_connections(self, mock_logger):
         server_instance = LogServer()
         server_instance.number_of_connections = 7
 
@@ -230,7 +233,8 @@ class TestHandleReceiveLogline(unittest.IsolatedAsyncioTestCase):
 
 
 class TestSendLogline(unittest.IsolatedAsyncioTestCase):
-    async def test_send_logline_with_logline(self):
+    @patch('src.logserver.server.logger')
+    async def test_send_logline_with_logline(self, mock_logger):
         server_instance = LogServer()
         writer = AsyncMock()
         logline = "Test logline"
@@ -252,7 +256,8 @@ class TestSendLogline(unittest.IsolatedAsyncioTestCase):
 
 
 class TestReceiveLogline(unittest.IsolatedAsyncioTestCase):
-    async def test_receive_logline(self):
+    @patch('src.logserver.server.logger')
+    async def test_receive_logline(self, mock_logger):
         reader = AsyncMock()
         data_queue = MagicMock()
         server_instance = LogServer()
@@ -284,9 +289,10 @@ class TestGetNextLogline(unittest.TestCase):
 
 
 class TestMainFunction(unittest.TestCase):
+    @patch('src.logserver.server.logger')
     @patch('src.logserver.server.asyncio.run')
     @patch('src.logserver.server.LogServer')
-    def test_main(self, mock_log_server_class, mock_asyncio_run):
+    def test_main(self, mock_log_server_class, mock_asyncio_run, mock_logger):
         # Arrange
         mock_server_instance = MagicMock()
         mock_log_server_class.return_value = mock_server_instance

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,9 +15,10 @@ class TestSetupConfig(unittest.TestCase):
         mock_yaml_safe_load.assert_called_once()
         self.assertEqual(result, {"some_yaml_data": "value"})
 
+    @patch('src.base.utils.logger')
     @patch("src.base.utils.CONFIG_FILEPATH", "fake/path/config.yaml")
     @patch("builtins.open", side_effect=FileNotFoundError)
-    def test_load_config_file_not_found(self, mock_open_file):
+    def test_load_config_file_not_found(self, mock_open_file, mock_logger):
         with self.assertRaises(FileNotFoundError):
             setup_config()
 


### PR DESCRIPTION
The logger is now mocked in the tests, so that its messages are not shown with each test run. The `train` files are now excluded from the coverage.