### PR TITLE
Fix missing requirement in `.readthedocs.yml`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,7 @@ python:
     - requirements: requirements/requirements.inspector.txt
     - requirements: requirements/requirements.detector.txt
     - requirements: requirements/requirements.train.txt
+    - requirements: requirements/requirements.logserver.txt
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Related to #32 and #36