### PR TITLE
Add docstrings and fix closing of LogServer

### DIFF
--- a/src/logserver/server.py
+++ b/src/logserver/server.py
@@ -83,7 +83,9 @@ class LogServer:
         finally:
             send_server.close()
             receive_server.close()
-            await asyncio.gather(send_server.wait_closed(), receive_server.wait_closed())
+            await asyncio.gather(
+                send_server.wait_closed(), receive_server.wait_closed()
+            )
             logger.debug("Both sockets closed.")
 
     async def handle_connection(self, reader, writer, sending: bool) -> None:

--- a/src/prefilter/prefilter.py
+++ b/src/prefilter/prefilter.py
@@ -42,7 +42,11 @@ class Prefilter:
         self.kafka_consume_handler = KafkaConsumeHandler(topic="Prefilter")
         logger.debug("Initialized Prefilter.")
 
-    def get_and_fill_data(self):
+    def get_and_fill_data(self) -> None:
+        """
+        Clears data already stored and consumes new data. Unpacks the data and checks if it is empty. If that is the
+        case, an info message is shown, otherwise the data is stored internally, including timestamps.
+        """
         logger.debug("Checking for existing data...")
         if self.unfiltered_data:
             logger.warning("Overwriting existing data by new message...")
@@ -89,6 +93,9 @@ class Prefilter:
         logger.info("Data successfully filtered.")
 
     def send_filtered_data(self):
+        """
+        Sends the filtered data if available via the :class:`KafkaProduceHandler`.
+        """
         if not self.unfiltered_data:
             logger.debug("No unfiltered or filtered data is available.")
             return
@@ -129,7 +136,19 @@ class Prefilter:
         logger.debug("Cleared data.")
 
 
-def main(one_iteration: bool = False):
+def main(one_iteration: bool = False) -> None:
+    """
+    Runs the main loop with by
+
+    1. Retrieving new data,
+    2. Filtering the data and
+    3. Sending the filtered data if not empty.
+
+    Stops by a ``KeyboardInterrupt``, any internal data is lost.
+
+    Args:
+        one_iteration (bool): Only one iteration is done if True (for testing purposes). False by default.
+    """
     logger.info("Starting Prefilter...")
     prefilter = Prefilter()
     logger.info(f"Prefilter started.")


### PR DESCRIPTION
I added missing docstrings to the `LogServer` and `Prefilter` code. Additionally, instead of implementing a `close` method for the `LogServer`, I adjusted the `open()` method to securely stop the instance. Resolves #24