### PR TITLE
Fix server receiving with separator

### DIFF
--- a/.github/workflows/build_test_macos.yml
+++ b/.github/workflows/build_test_macos.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-13" ]
+        os: [ "macos-14" ]
         python-version: [ "3.11",
                           "3.10",
         ]
@@ -32,6 +32,7 @@ jobs:
 
       - name: Install requirements
         run: |
+          brew install libomp
           python -m pip install --upgrade pip
           python -m pip install pyyaml
           python -m pip install -r requirements/requirements.dev.txt -r requirements/requirements.detector.txt -r requirements/requirements.logcollector.txt -r requirements/requirements.prefilter.txt -r requirements/requirements.inspector.txt -r requirements/requirements.logserver.txt

--- a/.github/workflows/build_test_macos.yml
+++ b/.github/workflows/build_test_macos.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-12" ]
+        os: [ "macos-14" ]
         python-version: [ "3.11",
                           "3.10",
         ]

--- a/.github/workflows/build_test_macos.yml
+++ b/.github/workflows/build_test_macos.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-14" ]
+        os: [ "macos-13" ]
         python-version: [ "3.11",
                           "3.10",
         ]

--- a/docker/docker-compose.kafka.yml
+++ b/docker/docker-compose.kafka.yml
@@ -5,6 +5,7 @@ services:
     networks:
       heidgaf:
         ipv4_address: 172.27.0.2
+    restart: "unless-stopped"
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_SERVER_ID: 1

--- a/src/logserver/server.py
+++ b/src/logserver/server.py
@@ -234,7 +234,7 @@ class LogServer:
             except asyncio.exceptions.IncompleteReadError as e:
                 logger.warning(f"Ignoring message: No separator symbol found: {e}")
                 break
-            except asyncio.LimitOverrunError as e:
+            except asyncio.LimitOverrunError:
                 logger.error(f"Message size exceeded, separator symbol not found")
                 break
             except Exception as e:

--- a/src/mock/generator.py
+++ b/src/mock/generator.py
@@ -4,12 +4,10 @@ import sys
 import time
 
 sys.path.append(os.getcwd())
-from src.base.log_config import setup_logging
 from src.mock.log_generator import generate_dns_log_line
 from src.base.log_config import get_logger
 
 logger = get_logger()
-
 
 if __name__ == "__main__":
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as client_socket:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -346,13 +346,15 @@ class TestSendLogline(unittest.IsolatedAsyncioTestCase):
 
 class TestReceiveLogline(unittest.IsolatedAsyncioTestCase):
     @patch("src.logserver.server.logger")
-    async def test_receive_logline(self, mock_logger):
+    async def test_receive_one_logline(self, mock_logger):
         reader = AsyncMock()
         data_queue = MagicMock()
         server_instance = LogServer()
         server_instance.data_queue = data_queue
 
-        reader.read = AsyncMock(side_effect=[b"Test message 1", b"Test message 2", b""])
+        reader.readuntil = AsyncMock(
+            side_effect=[b"Test message 1\n", b"Test message 2\n", b""]
+        )
 
         receive_task = asyncio.create_task(server_instance.receive_logline(reader))
         await receive_task

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -346,7 +346,7 @@ class TestSendLogline(unittest.IsolatedAsyncioTestCase):
 
 class TestReceiveLogline(unittest.IsolatedAsyncioTestCase):
     @patch("src.logserver.server.logger")
-    async def test_receive_one_logline(self, mock_logger):
+    async def test_receive_logline(self, mock_logger):
         reader = AsyncMock()
         data_queue = MagicMock()
         server_instance = LogServer()
@@ -363,6 +363,45 @@ class TestReceiveLogline(unittest.IsolatedAsyncioTestCase):
         data_queue.put.assert_any_call("Test message 2")
 
         self.assertEqual(data_queue.put.call_count, 2)
+
+    @patch("src.logserver.server.logger")
+    async def test_receive_without_separator(self, mock_logger):
+        reader = AsyncMock()
+        data_queue = MagicMock()
+        server_instance = LogServer()
+        server_instance.data_queue = data_queue
+
+        reader.readuntil = AsyncMock(
+            side_effect=asyncio.exceptions.IncompleteReadError(b"", 100)
+        )
+
+        # noinspection PyAsyncCall
+        asyncio.create_task(server_instance.receive_logline(reader))
+
+    @patch("src.logserver.server.logger")
+    async def test_receive_too_long(self, mock_logger):
+        reader = AsyncMock()
+        data_queue = MagicMock()
+        server_instance = LogServer()
+        server_instance.data_queue = data_queue
+
+        reader.readuntil = AsyncMock(side_effect=asyncio.LimitOverrunError("", 1))
+
+        # noinspection PyAsyncCall
+        asyncio.create_task(server_instance.receive_logline(reader))
+
+    @patch("src.logserver.server.logger")
+    async def test_receive_raise_other_exception(self, mock_logger):
+        reader = AsyncMock()
+        data_queue = MagicMock()
+        server_instance = LogServer()
+        server_instance.data_queue = data_queue
+
+        reader.readuntil = AsyncMock(side_effect=ValueError("Something went wrong"))
+
+        with self.assertRaises(ValueError):
+            task = asyncio.create_task(server_instance.receive_logline(reader))
+            await task
 
 
 class TestGetNextLogline(unittest.TestCase):


### PR DESCRIPTION
When sending many log lines almost simultaneously to the `LogServer`, they were received as one message and therefore invalid. Now messages sent need to be separated by `\n`.