### PR TITLE
Remove timestamp format parameter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,7 +23,7 @@ pipeline:
   log_collection:
     collector:
       logline_format:
-        - [ "timestamp", RegEx, '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$' ]
+        - [ "timestamp", Timestamp, "%Y-%m-%dT%H:%M:%S.%fZ" ]
         - [ "status_code", ListItem, [ "NOERROR", "NXDOMAIN" ], [ "NXDOMAIN" ] ]
         - [ "client_ip", IpAddress ]
         - [ "dns_server_ip", IpAddress ]
@@ -69,7 +69,6 @@ pipeline:
       batch_timeout: 2.0
 
 environment:
-  timestamp_format: "%Y-%m-%dT%H:%M:%S.%fZ"
   kafka_brokers:
     - hostname: kafka1
       port: 8097

--- a/src/base/data_classes/batch.py
+++ b/src/base/data_classes/batch.py
@@ -16,13 +16,9 @@ class Batch:
         metadata={"marshmallow_field": marshmallow.fields.UUID()}
     )
     begin_timestamp: datetime.datetime = field(
-        metadata={
-            "marshmallow_field": marshmallow.fields.DateTime("%Y-%m-%dT%H:%M:%S.%fZ")
-        }
+        metadata={"marshmallow_field": marshmallow.fields.DateTime()}  # uses ISO format
     )
     end_timestamp: datetime.datetime = field(
-        metadata={
-            "marshmallow_field": marshmallow.fields.DateTime("%Y-%m-%dT%H:%M:%S.%fZ")
-        }
+        metadata={"marshmallow_field": marshmallow.fields.DateTime()}  # uses ISO format
     )
     data: List = field(default_factory=list)

--- a/src/base/logline_handler.py
+++ b/src/base/logline_handler.py
@@ -90,17 +90,17 @@ class Timestamp(FieldType):
 
         return True
 
-    def get_timestamp(self, value) -> datetime.datetime:
+    def get_timestamp_as_str(self, value) -> str:
         """
-        Returns the timestamp object for a given timestamp with valid format.
+        Returns the timestamp as string for a given timestamp with valid format.
 
         Args:
             value: Correctly formatted timestamp according to self.timestamp_format
 
         Returns:
-            datetime.datetime object of the given timestamp
+            String of the given timestamp with standard format
         """
-        return datetime.datetime.strptime(value, self.timestamp_format)
+        return str(datetime.datetime.strptime(value, self.timestamp_format).isoformat())
 
 
 class IpAddress(FieldType):
@@ -271,7 +271,7 @@ class LoglineHandler:
                 return_dict[self.instances_by_position[i].name] = parts[i]
             else:
                 return_dict[self.instances_by_position[i].name] = (
-                    self.instances_by_position[i].get_timestamp(parts[i])
+                    self.instances_by_position[i].get_timestamp_as_str(parts[i])
                 )
 
         return return_dict.copy()

--- a/src/base/logline_handler.py
+++ b/src/base/logline_handler.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 
 from src.base.log_config import get_logger
@@ -61,6 +62,45 @@ class RegEx(FieldType):
             True if the value is valid, False otherwise
         """
         return True if re.match(self.pattern, value) else False
+
+
+class Timestamp(FieldType):
+    """
+    A :cls:`Timestamp` object takes a name, and a timestamp format, which a value needs to have.
+    """
+
+    def __init__(self, name: str, timestamp_format: str):
+        super().__init__(name)
+        self.timestamp_format = timestamp_format
+
+    def validate(self, value) -> bool:
+        """
+        Validates the input value.
+
+        Args:
+            value: The value to be validated
+
+        Returns:
+            True if the value is valid, False otherwise
+        """
+        try:
+            datetime.datetime.strptime(value, self.timestamp_format)
+        except ValueError:
+            return False
+
+        return True
+
+    def get_timestamp(self, value) -> datetime.datetime:
+        """
+        Returns the timestamp object for a given timestamp with valid format.
+
+        Args:
+            value: Correctly formatted timestamp according to self.timestamp_format
+
+        Returns:
+            datetime.datetime object of the given timestamp
+        """
+        return datetime.datetime.strptime(value, self.timestamp_format)
 
 
 class IpAddress(FieldType):
@@ -227,7 +267,12 @@ class LoglineHandler:
         return_dict = {}
 
         for i in range(self.number_of_fields):
-            return_dict[self.instances_by_position[i].name] = parts[i]
+            if not isinstance(self.instances_by_position[i], Timestamp):
+                return_dict[self.instances_by_position[i].name] = parts[i]
+            else:
+                return_dict[self.instances_by_position[i].name] = (
+                    self.instances_by_position[i].get_timestamp(parts[i])
+                )
 
         return return_dict.copy()
 
@@ -296,6 +341,11 @@ class LoglineHandler:
             if len_of_field_list != 3 or not isinstance(field_list[2], str):
                 raise ValueError("Invalid RegEx parameters")
             instance = cls(name=name, pattern=field_list[2])
+
+        elif cls_name == "Timestamp":
+            if len_of_field_list != 3 or not isinstance(field_list[2], str):
+                raise ValueError("Invalid Timestamp parameters")
+            instance = cls(name=name, timestamp_format=field_list[2])
 
         elif cls_name == "ListItem":
             if len_of_field_list not in [3, 4] or not isinstance(field_list[2], list):

--- a/src/inspector/inspector.py
+++ b/src/inspector/inspector.py
@@ -184,7 +184,12 @@ class Inspector:
             numpy.ndarray: 2-D numpy.ndarray including all steps.
         """
         logger.debug("Convert timestamps to numpy datetime64")
-        timestamps = np.array([np.datetime64(item["timestamp"]) for item in messages])
+        timestamps = np.array(
+            [
+                np.datetime64(datetime.fromisoformat(item["timestamp"]))
+                for item in messages
+            ]
+        )
 
         # Extract and convert the size values from "111b" to integers
         sizes = np.array([int(str(item["size"]).replace("b", "")) for item in messages])
@@ -258,7 +263,12 @@ class Inspector:
             numpy.ndarray: 2-D numpy.ndarray including all steps.
         """
         logger.debug("Convert timestamps to numpy datetime64")
-        timestamps = np.array([np.datetime64(item["timestamp"]) for item in messages])
+        timestamps = np.array(
+            [
+                np.datetime64(datetime.fromisoformat(item["timestamp"]))
+                for item in messages
+            ]
+        )
 
         logger.debug("Sort timestamps and count occurrences")
         sorted_indices = np.argsort(timestamps)

--- a/src/inspector/inspector.py
+++ b/src/inspector/inspector.py
@@ -33,7 +33,6 @@ ANOMALY_THRESHOLD = config["pipeline"]["data_inspection"]["inspector"][
 SCORE_THRESHOLD = config["pipeline"]["data_inspection"]["inspector"]["score_threshold"]
 TIME_TYPE = config["pipeline"]["data_inspection"]["inspector"]["time_type"]
 TIME_RANGE = config["pipeline"]["data_inspection"]["inspector"]["time_range"]
-TIMESTAMP_FORMAT = config["environment"]["timestamp_format"]
 CONSUME_TOPIC = config["environment"]["kafka_topics"]["pipeline"][
     "prefilter_to_inspector"
 ]
@@ -185,12 +184,7 @@ class Inspector:
             numpy.ndarray: 2-D numpy.ndarray including all steps.
         """
         logger.debug("Convert timestamps to numpy datetime64")
-        timestamps = np.array(
-            [
-                np.datetime64(datetime.strptime(item["timestamp"], TIMESTAMP_FORMAT))
-                for item in messages
-            ]
-        )
+        timestamps = np.array([np.datetime64(item["timestamp"]) for item in messages])
 
         # Extract and convert the size values from "111b" to integers
         sizes = np.array([int(str(item["size"]).replace("b", "")) for item in messages])
@@ -264,12 +258,7 @@ class Inspector:
             numpy.ndarray: 2-D numpy.ndarray including all steps.
         """
         logger.debug("Convert timestamps to numpy datetime64")
-        timestamps = np.array(
-            [
-                np.datetime64(datetime.strptime(item["timestamp"], TIMESTAMP_FORMAT))
-                for item in messages
-            ]
-        )
+        timestamps = np.array([np.datetime64(item["timestamp"]) for item in messages])
 
         logger.debug("Sort timestamps and count occurrences")
         sorted_indices = np.argsort(timestamps)

--- a/src/logcollector/batch_handler.py
+++ b/src/logcollector/batch_handler.py
@@ -216,13 +216,9 @@ class BufferedBatch:
 
             data = {
                 "batch_id": batch_id,
-                "begin_timestamp": datetime.datetime.strptime(
-                    begin_timestamp,
-                    "%Y-%m-%dT%H:%M:%S.%fZ",
-                ),
-                "end_timestamp": datetime.datetime.strptime(
-                    _get_last_timestamp_of_batch(),
-                    "%Y-%m-%dT%H:%M:%S.%fZ",
+                "begin_timestamp": datetime.datetime.fromisoformat(begin_timestamp),
+                "end_timestamp": datetime.datetime.fromisoformat(
+                    _get_last_timestamp_of_batch()
                 ),
                 "data": buffer_data + self.batch[key],
             }
@@ -406,7 +402,7 @@ class BufferedBatchSender:
         Dispatch all batches for the Kafka queue
 
         Args:
-            reset_timer (bool): whether or not the timer should be reset
+            reset_timer (bool): whether the timer should be reset
         """
         number_of_keys = 0
         total_number_of_batch_messages = self.batch.get_message_count_for_batch()
@@ -456,7 +452,7 @@ class BufferedBatchSender:
 
     def _send_data_packet(self, key: str, data: dict) -> None:
         """
-        Sends a packet of a batch to the defined Kafka topic
+        Sends a packet of a Batch to the defined Kafka topic
 
         Args:
             key (str): key to identify the batch

--- a/src/logcollector/batch_handler.py
+++ b/src/logcollector/batch_handler.py
@@ -20,7 +20,6 @@ logger = get_logger(module_name)
 config = setup_config()
 BATCH_SIZE = config["pipeline"]["log_collection"]["batch_handler"]["batch_size"]
 BATCH_TIMEOUT = config["pipeline"]["log_collection"]["batch_handler"]["batch_timeout"]
-TIMESTAMP_FORMAT = config["environment"]["timestamp_format"]
 PRODUCE_TOPIC = config["environment"]["kafka_topics"]["pipeline"][
     "batch_sender_to_prefilter"
 ]
@@ -322,11 +321,8 @@ class BufferedBatch:
     @staticmethod
     def _sort_by_timestamp(
         data: list[tuple[str, str]],
-        timestamp_format: str = TIMESTAMP_FORMAT,
     ) -> list[str]:
-        sorted_data = sorted(
-            data, key=lambda x: datetime.datetime.strptime(x[0], timestamp_format)
-        )
+        sorted_data = sorted(data, key=lambda x: x[0])
         loglines = [message for _, message in sorted_data]
 
         return loglines

--- a/src/logcollector/collector.py
+++ b/src/logcollector/collector.py
@@ -128,7 +128,7 @@ class LogCollector:
             dict(
                 logline_id=logline_id,
                 subnet_id=subnet_id,
-                timestamp=fields.get("timestamp"),
+                timestamp=datetime.datetime.fromisoformat(fields.get("timestamp")),
                 status_code=fields.get("status_code"),
                 client_ip=fields.get("client_ip"),
                 record_type=fields.get("record_type"),

--- a/src/logcollector/collector.py
+++ b/src/logcollector/collector.py
@@ -24,7 +24,6 @@ IPV4_PREFIX_LENGTH = config["pipeline"]["log_collection"]["batch_handler"]["subn
 IPV6_PREFIX_LENGTH = config["pipeline"]["log_collection"]["batch_handler"]["subnet_id"][
     "ipv6_prefix_length"
 ]
-TIMESTAMP_FORMAT = config["environment"]["timestamp_format"]
 REQUIRED_FIELDS = [
     "timestamp",
     "status_code",
@@ -129,9 +128,7 @@ class LogCollector:
             dict(
                 logline_id=logline_id,
                 subnet_id=subnet_id,
-                timestamp=datetime.datetime.strptime(
-                    fields.get("timestamp"), TIMESTAMP_FORMAT
-                ),
+                timestamp=fields.get("timestamp"),
                 status_code=fields.get("status_code"),
                 client_ip=fields.get("client_ip"),
                 record_type=fields.get("record_type"),

--- a/tests/logcollector/test_batch_handler.py
+++ b/tests/logcollector/test_batch_handler.py
@@ -383,7 +383,7 @@ class TestSendDataPacket(unittest.TestCase):
         mock_produce_handler_instance.produce.assert_called_once_with(
             topic="test_topic",
             data='{"batch_id": "b4b6f13e-d064-4ab7-94ed-d02b46063308", "begin_timestamp": '
-            '"2024-12-06T13:12:30.324015Z", "end_timestamp": "2024-12-06T13:12:31.832173Z", '
+            '"2024-12-06T13:12:30.324015", "end_timestamp": "2024-12-06T13:12:31.832173", '
             '"data": ["test_data"]}',
             key=key,
         )

--- a/tests/logcollector/test_buffered_batch.py
+++ b/tests/logcollector/test_buffered_batch.py
@@ -637,10 +637,16 @@ class TestCompleteBatch(unittest.TestCase):
 
         # Assert
         self.assertEqual(
-            datetime.datetime(2024, 5, 21, 8, 31, 28, 119000), data["begin_timestamp"]
+            datetime.datetime(
+                2024, 5, 21, 8, 31, 28, 119000, tzinfo=datetime.timezone.utc
+            ),
+            data["begin_timestamp"],
         )
         self.assertEqual(
-            datetime.datetime(2024, 5, 21, 8, 31, 28, 249000), data["end_timestamp"]
+            datetime.datetime(
+                2024, 5, 21, 8, 31, 28, 249000, tzinfo=datetime.timezone.utc
+            ),
+            data["end_timestamp"],
         )
         self.assertEqual(expected_messages, data["data"])
 
@@ -682,16 +688,28 @@ class TestCompleteBatch(unittest.TestCase):
 
         # Assert
         self.assertEqual(
-            datetime.datetime(2024, 5, 21, 8, 31, 28, 119000), data_1["begin_timestamp"]
+            datetime.datetime(
+                2024, 5, 21, 8, 31, 28, 119000, tzinfo=datetime.timezone.utc
+            ),
+            data_1["begin_timestamp"],
         )
         self.assertEqual(
-            datetime.datetime(2024, 5, 21, 8, 31, 28, 249000), data_1["end_timestamp"]
+            datetime.datetime(
+                2024, 5, 21, 8, 31, 28, 249000, tzinfo=datetime.timezone.utc
+            ),
+            data_1["end_timestamp"],
         )
         self.assertEqual(
-            datetime.datetime(2024, 5, 21, 8, 31, 28, 119000), data_2["begin_timestamp"]
+            datetime.datetime(
+                2024, 5, 21, 8, 31, 28, 119000, tzinfo=datetime.timezone.utc
+            ),
+            data_2["begin_timestamp"],
         )
         self.assertEqual(
-            datetime.datetime(2024, 5, 21, 8, 31, 28, 749000), data_2["end_timestamp"]
+            datetime.datetime(
+                2024, 5, 21, 8, 31, 28, 749000, tzinfo=datetime.timezone.utc
+            ),
+            data_2["end_timestamp"],
         )
         self.assertEqual({key: [message_3, message_4]}, sut.buffer)
         self.assertEqual({}, sut.batch)

--- a/tests/logcollector/test_collector.py
+++ b/tests/logcollector/test_collector.py
@@ -177,9 +177,6 @@ class TestSend(unittest.TestCase):
 
         # Act
         with (
-            patch(
-                "src.logcollector.collector.TIMESTAMP_FORMAT", "%Y-%m-%d %H:%M:%S.%f"
-            ),
             patch("src.logcollector.collector.IPV4_PREFIX_LENGTH", 24),
             patch(
                 "src.logcollector.collector.uuid.uuid4",

--- a/tests/miscellaneous/test_field_type.py
+++ b/tests/miscellaneous/test_field_type.py
@@ -2,7 +2,7 @@ import ipaddress
 import re
 import unittest
 
-from src.base.logline_handler import FieldType, RegEx, IpAddress, ListItem
+from src.base.logline_handler import FieldType, RegEx, IpAddress, ListItem, Timestamp
 
 
 class TestFieldType(unittest.TestCase):
@@ -21,6 +21,38 @@ class TestFieldType(unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             sut.validate(value="test")
+
+
+class TestTimestamp(unittest.TestCase):
+    def test_init(self):
+        # Arrange
+        name = "test_name"
+        timestamp_format = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+        # Act
+        sut = Timestamp(name=name, timestamp_format=timestamp_format)
+
+        # Assert
+        self.assertEqual(name, sut.name)
+        self.assertEqual(timestamp_format, sut.timestamp_format)
+
+    def test_validate_successful(self):
+        # Arrange
+        name = "test_name"
+        timestamp_format = "%Y-%m-%dT%H:%M:%S.%fZ"
+        sut = Timestamp(name=name, timestamp_format=timestamp_format)
+
+        # Act and Assert
+        self.assertTrue(sut.validate(value="2024-07-28T14:45:30.123Z"))
+
+    def test_validate_unsuccessful(self):
+        # Arrange
+        name = "test_name"
+        timestamp_format = "%Y-%m-%d %H:%M:%S.%f"
+        sut = Timestamp(name=name, timestamp_format=timestamp_format)
+
+        # Act and Assert
+        self.assertFalse(sut.validate(value="2024-07-28T14:45:30.123Z"))
 
 
 class TestRegEx(unittest.TestCase):

--- a/tests/miscellaneous/test_logline_handler.py
+++ b/tests/miscellaneous/test_logline_handler.py
@@ -1,4 +1,3 @@
-import datetime
 import re
 import unittest
 from unittest.mock import patch, MagicMock

--- a/tests/miscellaneous/test_logline_handler.py
+++ b/tests/miscellaneous/test_logline_handler.py
@@ -522,6 +522,17 @@ class TestCreateInstanceFromListEntry(unittest.TestCase):
         # Assert
         self.assertEqual(str(context.exception), "Invalid RegEx parameters")
 
+    def test_invalid_timestamp_parameters(self):
+        # Arrange
+        field_list = ["test_name", "Timestamp"]
+
+        # Act & Assert
+        with self.assertRaises(ValueError) as context:
+            LoglineHandler._create_instance_from_list_entry(field_list)
+
+        # Assert
+        self.assertEqual(str(context.exception), "Invalid Timestamp parameters")
+
     def test_invalid_list_item_parameters(self):
         # Arrange
         field_list = ["test_name", "ListItem", "not_a_list"]

--- a/tests/miscellaneous/test_logline_handler.py
+++ b/tests/miscellaneous/test_logline_handler.py
@@ -307,9 +307,7 @@ class TestValidateLoglineAndGetFieldsAsJson(unittest.TestCase):
     def test_validate_true(self):
         # Arrange
         expected_result = {
-            "timestamp": datetime.datetime.strptime(
-                "2024-07-28 14:45:30.123", "%Y-%m-%d %H:%M:%S.%f"
-            ),
+            "timestamp": "2024-07-28T14:45:30.123000",
             "status_code": "NXDOMAIN",
             "client_ip": "127.0.0.2",
             "dns_server_ip": "126.24.5.20",

--- a/tests/miscellaneous/test_marshmallow.py
+++ b/tests/miscellaneous/test_marshmallow.py
@@ -10,11 +10,11 @@ class TestClearData(unittest.TestCase):
     def test_clear_data_with_existing_data(self):
         json_data = {
             "batch_id": str(uuid.uuid4()),
-            "begin_timestamp": "2024-05-21T08:31:27.000000Z",
-            "end_timestamp": "2024-05-21T08:31:29.000000Z",
+            "begin_timestamp": "2024-05-21T08:31:27",
+            "end_timestamp": "2024-05-21T08:31:29",
             "data": [
                 {
-                    "timestamp": "2024-05-21T08:31:28.119Z",
+                    "timestamp": "2024-05-21T08:31:28.119",
                     "status": "NOERROR",
                     "client_ip": "192.168.0.105",
                     "dns_ip": "8.8.8.8",

--- a/tests/prefilter/test_prefilter.py
+++ b/tests/prefilter/test_prefilter.py
@@ -389,8 +389,8 @@ class TestSendFilteredData(unittest.TestCase):
         sut.begin_timestamp = datetime.datetime(2024, 5, 21, 8, 31, 27, 000000)
         sut.end_timestamp = datetime.datetime(2024, 5, 21, 8, 31, 29, 000000)
         expected_message = (
-            '{"batch_id": "5236b147-5b0d-44a8-981f-bd7da8c54733", "begin_timestamp": "2024-05-21T08:31:27.000000Z", '
-            '"end_timestamp": "2024-05-21T08:31:29.000000Z", "data": [{'
+            '{"batch_id": "5236b147-5b0d-44a8-981f-bd7da8c54733", "begin_timestamp": "2024-05-21T08:31:27", '
+            '"end_timestamp": "2024-05-21T08:31:29", "data": [{'
             '"timestamp": "2024-05-21T08:31:28.119Z", "status": "NXDOMAIN", "client_ip": "192.168.1.105", '
             '"dns_ip": "8.8.8.8", "host_domain_name": "www.heidelberg-botanik.de", "record_type": "A", "response_ip": '
             '"b937:2f2e:2c1c:82a:33ad:9e59:ceb9:8e1", "size": "150b"}, {"timestamp": "2024-06-01T02:31:07.943Z", '


### PR DESCRIPTION
The redundant configuration variable for setting the timestamp format has been removed. A new `FieldType` for timestamps has been added, which takes the timestamp format as input. The timestamp format throughout the pipeline has been generalized to the ISO format and the configured variable only changes the input format.

Resolves #69.